### PR TITLE
Windows integration

### DIFF
--- a/conda.m
+++ b/conda.m
@@ -170,8 +170,14 @@ methods (Static)
 		end
 		p(rm_this) = [];
 
-		% add the path of the env we want to switch to
-		this_env_path = [env_paths{strcmp(env_names,env)} filesep 'bin'];
+		% add the path of the env we want to switch to. On Windows the 
+		% executable lives in the main env directory, on *NIX in the bin 
+		% subfolder.
+		if ~ispc
+			this_env_path = [env_paths{strcmp(env_names,env)} filesep 'bin'];
+		else
+			this_env_path = env_paths{strcmp(env_names,env)};
+		end
 		p = [this_env_path p];
 		p = strjoin(p,pathsep);
 


### PR DESCRIPTION
Conda places the python executable to `<conda_dir>\envs\<env_name>\python.exe` on Windows, but to  `<conda_dir>\envs\<env_name>\bin\python.exe` on unix. A simple platform check resolves that.

Anything else that might make problems?