### PR TITLE
bugfix - conda-init: added if-else test if conda base path contains condabin

### DIFF
--- a/conda.m
+++ b/conda.m
@@ -57,7 +57,11 @@ methods (Static)
 			getpref('condalab','base_path');
 		catch
 			str = input('Enter the path to your conda installation:  \n','s');
-			str = strrep(str,[filesep 'conda'],'');
+         if contains(str,['condabin' filesep 'conda'])
+            str = strrep(str,['condabin' filesep 'conda'],'condabin');
+         else
+			   str = strrep(str,[filesep 'conda'],'');
+         end
 			setpref('condalab','base_path',str)
 		end
 


### PR DESCRIPTION
if the base path is something like: `/Users/someuser/opt/anaconda3/condabin/conda` then the current conda init method would set the base-path pref to `/Users/someuser/opt/anaconda3bin` so I added a simple check for the presence of condabin/ in the user input path.